### PR TITLE
DS-630: GradeEvent is now supported - move to released directories

### DIFF
--- a/src/test/java/org/imsglobal/caliper/assessmentService/events/development/CaliperEventSpanishRiGradedTest.java
+++ b/src/test/java/org/imsglobal/caliper/assessmentService/events/development/CaliperEventSpanishRiGradedTest.java
@@ -18,18 +18,7 @@
 
 package org.imsglobal.caliper.assessmentService.events.development;
 
-import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
-import static org.imsglobal.caliper.events.HMHConstants.ACTIVITY_REF_ID;
-import static org.imsglobal.caliper.events.HMHConstants.BASE_IRI;
-import static org.imsglobal.caliper.events.HMHConstants.BASE_URN;
-import static org.imsglobal.caliper.events.HMHConstants.DISTRICT_REF_ID;
-import static org.imsglobal.caliper.events.HMHConstants.OBJECT_ID;
-import static org.imsglobal.caliper.events.HMHConstants.SCHOOL_REF_ID;
-import static org.imsglobal.caliper.events.HMHConstants.STUDENT_USER_REF_ID;
-import static org.imsglobal.caliper.events.HMHConstants.LAST_ATTEMPT_ID;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.actions.Action;
 import org.imsglobal.caliper.context.JsonldContext;
@@ -53,6 +42,16 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
+import static org.imsglobal.caliper.events.HMHConstants.ACTIVITY_REF_ID;
+import static org.imsglobal.caliper.events.HMHConstants.BASE_IRI;
+import static org.imsglobal.caliper.events.HMHConstants.BASE_URN;
+import static org.imsglobal.caliper.events.HMHConstants.DISTRICT_REF_ID;
+import static org.imsglobal.caliper.events.HMHConstants.LAST_ATTEMPT_ID;
+import static org.imsglobal.caliper.events.HMHConstants.OBJECT_ID;
+import static org.imsglobal.caliper.events.HMHConstants.SCHOOL_REF_ID;
+import static org.imsglobal.caliper.events.HMHConstants.STUDENT_USER_REF_ID;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
 public class CaliperEventSpanishRiGradedTest {
@@ -121,7 +120,7 @@ public class CaliperEventSpanishRiGradedTest {
     public void caliperEventSerializesToJSON() throws Exception {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
-        String fixture = jsonFixture("fixtures/hmh/hmh-assessment-service/development/caliperEventSpanishRiGraded.json");
+        String fixture = jsonFixture("fixtures/hmh/hmh-assessment-service/released/caliperEventSpanishRiGraded.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 

--- a/src/test/java/org/imsglobal/caliper/partner/events/development/RenLearnStarScoreEventGradedTest.java
+++ b/src/test/java/org/imsglobal/caliper/partner/events/development/RenLearnStarScoreEventGradedTest.java
@@ -126,7 +126,7 @@ public class RenLearnStarScoreEventGradedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/hmh/hmh-renlearn/development/caliperEventStarScoreGraded.json");
+        String fixture = jsonFixture("fixtures/hmh/hmh-renlearn/released/caliperEventStarScoreGraded.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 

--- a/src/test/java/org/imsglobal/caliper/ri/events/released/GradeEventGradedTest.java
+++ b/src/test/java/org/imsglobal/caliper/ri/events/released/GradeEventGradedTest.java
@@ -19,8 +19,6 @@
 package org.imsglobal.caliper.ri.events.released;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import org.apache.commons.lang.time.DateFormatUtils;
 import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.actions.Action;
 import org.imsglobal.caliper.context.JsonldContext;
@@ -56,9 +54,7 @@ import static org.imsglobal.caliper.events.HMHConstants.OBJECT_ID;
 import static org.imsglobal.caliper.events.HMHConstants.SCHOOL_REF_ID;
 import static org.imsglobal.caliper.events.HMHConstants.STUDENT_USER_REF_ID;
 import static org.imsglobal.caliper.ri.events.RIConstants.APP_NAME;
-import static org.imsglobal.caliper.ri.events.RIConstants.RIMI_DEVELOPMENT_DIRECTORY;
-
-import java.util.Calendar;
+import static org.imsglobal.caliper.ri.events.RIConstants.RIMI_RELEASED_DIRECTORY;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
 public class GradeEventGradedTest {
@@ -128,7 +124,7 @@ public class GradeEventGradedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture(RIMI_DEVELOPMENT_DIRECTORY+"caliperEventGradeGraded.json");
+        String fixture = jsonFixture(RIMI_RELEASED_DIRECTORY+"caliperEventGradeGraded.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 


### PR DESCRIPTION
DS-630: GradeEvent is now supported by Ed Analytics so moving to 'released' directories.
Also linked to https://github.com/hmhco/caliper-common-fixtures/pull/13